### PR TITLE
perf: Optimize memory allocations in Merkle operations

### DIFF
--- a/src/sha2.rs
+++ b/src/sha2.rs
@@ -10,9 +10,7 @@ pub use solana_sha256_hasher::{hash, hashv};
 /// # Example
 /// ```
 /// use svm_hash::sha2::double_hash;
-/// use svm_hash::sha2::{LEAF_PREFIX, NODE_PREFIX};
-///
-/// let hash = double_hash(b"message", LEAF_PREFIX, NODE_PREFIX);
+/// let hash = double_hash(b"message", b"leaf_prefix", b"node_prefix");
 /// ```
 pub fn double_hash(message: &[u8], first_prefix: &[u8], second_prefix: &[u8]) -> Hash {
     let first = hashv(&[first_prefix, message]);


### PR DESCRIPTION
Summary
----
- Implement in-place root_from_leaf_hashes O(log n) -> O(1) allocations
- Pre-allocate vectors with exact capacity in proof generation
- Pre-allocate hash_leaves vector to avoid growth reallocations
- Remove TODO comment