### PR TITLE
uptick version to 0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "svm-hash"
 description = "Solana-compatible hashing and Merkle tree utilities"
-version = "0.1.0-beta.6"
+version = "0.1.0"
 
 edition = "2021"
 homepage = "https://doublezero.xyz"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# svm-hash
+
+A Rust library providing Solana-compatible hashing and Merkle tree utilities.
+
+## Features
+
+- **Double hashing**: Domain-separated double SHA-256 hashing compatible with Solana.
+- **Merkle trees**: Complete Merkle tree implementation with proof generation and verification.
+- **Generic support**: Works with any data type implementing `AsRef<[u8]>`.
+- **`bytemuck` integration**: Zero-copy serialization support with the `bytemuck` feature.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.88"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
Also adds README.

Closes https://github.com/doublezerofoundation/svm-hash-rs/issues/1.