### PR TITLE
uptick version to 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+## Unreleased
+
+- uptick version to 0.2.0 ([#17])
+
+## [v0.1.0] 
+
+- add re-exports ([#3])
+- some clean-up ([#4])
+- perf: Optimize memory allocations in Merkle operations ([#5])
+- ci: add workflow ([#7])
+- add optional custom leaf prefix ([#10])
+- add borsh ([#11])
+- add indexed leaves ([#12])
+- make `leaf_index` pub ([#13])
+- reduce index type to u32 ([#14])
+- uptick version to 0.1.0 ([#15])
+
+[#3]: https://github.com/doublezerofoundation/svm-hash-rs/pull/3
+[#4]: https://github.com/doublezerofoundation/svm-hash-rs/pull/4
+[#5]: https://github.com/doublezerofoundation/svm-hash-rs/pull/5
+[#7]: https://github.com/doublezerofoundation/svm-hash-rs/pull/7
+[#10]: https://github.com/doublezerofoundation/svm-hash-rs/pull/10
+[#11]: https://github.com/doublezerofoundation/svm-hash-rs/pull/11
+[#12]: https://github.com/doublezerofoundation/svm-hash-rs/pull/12
+[#13]: https://github.com/doublezerofoundation/svm-hash-rs/pull/13
+[#14]: https://github.com/doublezerofoundation/svm-hash-rs/pull/14
+[#15]: https://github.com/doublezerofoundation/svm-hash-rs/pull/15
+[#17]: https://github.com/doublezerofoundation/svm-hash-rs/pull/17
+[v0.1.0]: https://github.com/doublezerofoundation/svm-hash-rs/tree/v0.1.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,20 +1,24 @@
 [package]
 name = "svm-hash"
 description = "Solana-compatible hashing and Merkle tree utilities"
-version = "0.1.0"
+version = "0.2.0"
 
 edition = "2021"
 homepage = "https://doublezero.xyz"
 keywords = ["solana", "hash", "merkle"]
 license = "Apache-2.0"
 repository = "https://github.com/doublezerofoundation/svm-hash-rs"
-rust-version = "1.83"
+rust-version = "1.84.1"
 
 [dependencies]
-borsh = { optional = true, version = "1.5", features = ["derive"] }
-bytemuck = { optional = true, version = "1.23", features = ["derive"]}
-solana-hash = "2"
-solana-sha256-hasher = "2"
+borsh = { optional = true, version = "1", features = ["derive"] }
+bytemuck = { optional = true, version = "1", features = ["derive"]}
+solana-hash = { version = "4", features = ["copy"] }
+solana-sha256-hasher = "3"
+
+[dev-dependencies]
+solana-hash = { version = "4", features = ["atomic"] }
+solana-sha256-hasher = { version = "3", features = ["sha2"] }
 
 [features]
 default = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.88"
+channel = "1.91"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
This version upticks `solana-hash` to v4 (compliant with Solana v3 crates) and `solana-sha256-hasher` to v3.

If your integration requires Solana v2, please use v0.1.0.

Closes https://github.com/malbeclabs/doublezero/issues/2330.